### PR TITLE
Improve overall navigation options in sidebar

### DIFF
--- a/lib/nextstrain/sphinx/theme/layout.html
+++ b/lib/nextstrain/sphinx/theme/layout.html
@@ -7,13 +7,17 @@
   by the theme *and also* can't refer to a theme-provided file when set by the
   doc project's conf.py.
 
+  `theme_logo_only` is set via a project's conf.py -> `html_theme_options` ->
+  `logo_only` value (default: false).
+
   We also adjust the rendering of the project name to remove the home icon.
 #}
 {% block sidebartitle %}
+
 {% set logo = logo if logo else 'nextstrain-logo.svg' if theme_logo else '' %}
 
 {% if logo %}
-  <a href="{{ pathto(master_doc) }}">
+  <a href="https://nextstrain.org">
     <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
   </a>
 {% endif %}

--- a/lib/nextstrain/sphinx/theme/layout.html
+++ b/lib/nextstrain/sphinx/theme/layout.html
@@ -8,7 +8,8 @@
   doc project's conf.py.
 
   `theme_logo_only` is set via a project's conf.py -> `html_theme_options` ->
-  `logo_only` value (default: false).
+  `logo_only` value (default: false). In the context of Nextstrain we use this
+  to determine whether or not to display the subproject name, version
 
   We also adjust the rendering of the project name to remove the home icon.
 #}
@@ -23,20 +24,31 @@
 {% endif %}
 
 {% if not theme_logo_only %}
-<a href="{{ pathto(master_doc) }}" class="project-name" alt="{{ _("Documentation Home") }}"> {{ project }}</a>
-{% endif %}
+  <div class="subproject">
+    <a href="{{ pathto(master_doc) }}" class="project-name" alt="{{ _("Documentation Home") }}">
+      {{ project }}
+    </a>
 
+    {#
+      NOTE the version only works on RTD (not locally) as the variables `nav_version` and
+      `current_version` don't seem to be set on a local build.
+    #}
+    {%- set nav_version = version %}
+    {% if READTHEDOCS and current_version %}
+      {%- set nav_version = current_version %}
+    {% endif %}
+    {% if nav_version %}
+      <span>
+        version: {{ nav_version }}
+      </span>
+    {% endif %}
 
-{% if theme_display_version %}
-  {%- set nav_version = version %}
-  {% if READTHEDOCS and current_version %}
-    {%- set nav_version = current_version %}
-  {% endif %}
-  {% if nav_version %}
-    <div class="version">
-      {{ nav_version }}
-    </div>
-  {% endif %}
+  </div>
+
+  <div>
+    (<a href="https://docs.nextstrain.org">Click here</a> to return to the main nextstrain docs)
+  </div>
+
 {% endif %}
 
 {% include "searchbox.html" %}

--- a/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
+++ b/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
@@ -170,9 +170,6 @@ footer span.commit code,
 .wy-nav-content a.btn-neutral:hover {
   background-color: var(--text-color) !important;
   color: var(--content-background-color) !important;
-<<<<<<< HEAD
-}
-=======
 }
 
 /* Footer styles. Largely chosen to mimic the previous rendering of the docs. See
@@ -243,4 +240,3 @@ footer div.avatar > span > a > img {
   border-radius: 50%;
   vertical-align: middle;
 }
->>>>>>> footer

--- a/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
+++ b/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
@@ -77,24 +77,28 @@ footer span.commit code,
   background: inherit;
 }
 
-/* Project name and version */
-.wy-side-nav-search > a {
-  color: var(--heading-color);
-  margin-bottom: 0;
+/* Sub-project name, version (optional) and link back to the main docs */
+.wy-side-nav-search > div.subproject {
+  margin-top: -1rem;
 }
-
-.wy-side-nav-search > a.project-name {
+.wy-side-nav-search > div.subproject > a { /* subproject name */
   font-size: 1.5rem;
   font-weight: 500;
-  margin-bottom: 0.8rem;
-}
-
-.wy-side-nav-search > div.version {
   color: var(--heading-color);
 }
-
-.wy-side-nav-search > a.project-name + div.version {
-  margin-top: -0.8rem;
+.wy-side-nav-search > div.subproject > span { /* version name */
+  display: inline-block;
+  font-size: 1.1rem;
+  font-weight: 300;
+  color: var(--heading-color);
+}
+.wy-side-nav-search > div.subproject + div { /* go back to main docs link */
+  font-style: italic;
+  font-size: 1rem;
+  font-weight: 300;
+  line-height: 1rem;
+  color: var(--heading-color);
+  margin-bottom: 1.2rem;
 }
 
 /* Remove blue accent border */


### PR DESCRIPTION
### Description of proposed changes    

This PR provides users with a clear way to return to the main nextstrain.org site (via the nextstrain logo, which is consistent with other parts of the nextstrain ecosystem) and, when within a subproject's docs provides a clear way to return to return to the main docs.nextstrain.org docs. Note that the second part here will be much improved by our plans to move to a unified TOC.

Screenshot of Augur docs (branch `migrate-docs`) build under this theme:

![image](https://user-images.githubusercontent.com/8350992/97951541-61d2c100-1dff-11eb-92f2-ce65654a9549.png)

(Note that the version information doesn't come up when built locally, but should appear on the RTD build.)