### PR TITLE
Revert back to using a monospace font for inline literals

### DIFF
--- a/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
+++ b/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
@@ -56,8 +56,6 @@ footer span.commit code,
   border-radius: 3px;
   border: 0;
   color: inherit;
-  font-family: inherit;
-  font-size: 100%;
   margin: 0;
   padding: 3.2px 6.4px;
 }


### PR DESCRIPTION
These literals usually contain code or commands that benefit from the
clarity and convention of monospace.

The font was switched from monospace → variable width along with broader
style changes in "Modify styling of main docs content" (3b2302f).  I
suspcect it was unintentional, as the basis for those style changes—a
past version of <https://nextstrain.github.io/auspice/>—also seems to
have used a monospace font for inline literals.
