### PR TITLE
Change logo link to https://docs.nextstrain.org

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -29,7 +29,7 @@ options are supported:
        Defaults to true.
 
 :logo_link: URL to use for the logo's link.  Defaults to
-            <https://nextstrain.org>.
+            <https://docs.nextstrain.org>.
 
 If your project wants to display its own logo, just set Sphinx's ``html_logo``
 to point to the image file in your Sphinx project.

--- a/README.rst
+++ b/README.rst
@@ -22,11 +22,14 @@ your ``conf.py`` file:
     html_theme = "nextstrain-sphinx-theme"
 
 This theme is based on sphinx_rtd_theme_ and accepts all of the same
-`configuration options`_ settable via ``html_theme_option``.  One additional
-option is supported:
+`configuration options`_ settable via ``html_theme_option``.  Two additional
+options are supported:
 
 :logo: Boolean determining if the Nextstrain logo should be displayed.
        Defaults to true.
+
+:logo_link: URL to use for the logo's link.  Defaults to
+            <https://nextstrain.org>.
 
 If your project wants to display its own logo, just set Sphinx's ``html_logo``
 to point to the image file in your Sphinx project.

--- a/lib/nextstrain/sphinx/theme/layout.html
+++ b/lib/nextstrain/sphinx/theme/layout.html
@@ -29,7 +29,7 @@
 {% set logo = logo if logo else 'nextstrain-logo.svg' if theme_logo else '' %}
 
 {% if logo %}
-  <a href="https://nextstrain.org">
+  <a href="{{ theme_logo_link }}">
     <img src="{{ pathto('_static/' + logo, 1) }}" class="logo" alt="{{ _('Logo') }}"/>
   </a>
 {% endif %}

--- a/lib/nextstrain/sphinx/theme/theme.conf
+++ b/lib/nextstrain/sphinx/theme/theme.conf
@@ -7,4 +7,4 @@ pygments_style = default
 [options]
 style_nav_header_background = #f2f2f2
 logo = True
-logo_link = https://nextstrain.org
+logo_link = https://docs.nextstrain.org

--- a/lib/nextstrain/sphinx/theme/theme.conf
+++ b/lib/nextstrain/sphinx/theme/theme.conf
@@ -7,3 +7,4 @@ pygments_style = default
 [options]
 style_nav_header_background = #f2f2f2
 logo = True
+logo_link = https://nextstrain.org


### PR DESCRIPTION
This feels more "right" to several members of the team.  I definitely
find myself surprised when I click the logo on the docs site and end up
on the nextstrain.org home page instead of the docs home page.