### PR TITLE
Show precise versions for stable and development ("latest")

### DIFF
--- a/lib/nextstrain/sphinx/theme/layout.html
+++ b/lib/nextstrain/sphinx/theme/layout.html
@@ -47,9 +47,15 @@
     {% if nav_version %}
       <div class="version">
         {% if nav_version == "stable" %}
-          {# don't show anything #}
+          stable version
+          {% if version and version != "stable" %}
+            <small>({{ version }})</small>
+          {% endif %}
         {% elif nav_version == "latest" %}
           development version
+          {% if commit %}
+            <small>(<tt>{{ commit }}</tt>)</small>
+          {% endif %}
         {% else %}
           version {{ nav_version }}
         {% endif %}


### PR DESCRIPTION
Make it even clearer what software revisions those labels represent.  

A `git describe` style string[^1] for development ("latest") would be even better than just the git revision, but that appears to be non-trivial to implement.

Resolves <https://github.com/nextstrain/augur/issues/817>.

h/t to @corneliusroemer for the suggestion and @huddlej for bringing it up again in <https://github.com/nextstrain/sphinx-theme/pull/15>.

[^1]: e.g. "${tag}-${n}-g${sha}" where ${tag} is the last/closest tag to the current commit, ${n} is the number of commits since that ${tag}, and ${sha} is the shortened id of the current commit.