### PR TITLE
Dock the floating RTD versions panel to the sidebar

### DIFF
--- a/lib/nextstrain/sphinx/theme/layout.html
+++ b/lib/nextstrain/sphinx/theme/layout.html
@@ -63,3 +63,49 @@
 {% include "searchbox.html" %}
 
 {% endblock %}
+
+
+{% block extrabody %}
+  <!--
+    Lie about what theme we really are when some RTD-injected JS fetches the
+    full versions panel from the RTD API.  RTD's JS replaces the stub versions
+    panel in the Sphinx-generated HTML with the full versions panel it fetches
+    from the RTD API.  If the API thinks we're not sphinx_rtd_theme, it will
+    serve us the wrong HTML and the panel will float as a "badge" when it
+    shouldn't.  As a customized version of sphinx_rtd_theme, we really do want
+    the same HTML it gets.  See also the diagnoses in
+    <https://github.com/nextstrain/docs.nextstrain.org/issues/76>.
+
+    This bit of JS finds the data RTD injects into the page and modifies it
+    before the code that RTD injects runs and looks at the data.  RTD's
+    <script>s (in <head>) run before this JS, but they wait until the DOM is
+    ready to actually do any work.  This gives us a chance to modify the data
+    during DOM load before the RTD code actually uses it.
+
+      -trs, 27 Jan 2022
+  -->
+  <script>
+    (() => {
+      try {
+        console.log("Lying about the theme to RTD's JS so the versions panel works properly. 🙈");
+
+        /* Update global variable, which is used in the request to get the RTD
+         * "footer" that includes the versions panel.
+         */
+        if (window.READTHEDOCS_DATA)
+          window.READTHEDOCS_DATA.theme = "sphinx_rtd_theme";
+
+        /* Update stored JSON in case anything else deserializes it later.
+         * Comments in the RTD-injected HTML source claim the global variable
+         * above is deprecated.
+         */
+        var script = document.querySelector("#READTHEDOCS_DATA");
+        if (script)
+          script.innerHTML = JSON.stringify({ ...JSON.parse(script.innerHTML), theme: "sphinx_rtd_theme" });
+      }
+      catch (err) {
+        console.log("Lying about the theme to RTD's JS failed… oh well. 🤷", err);
+      }
+    })();
+  </script>
+{% endblock %}


### PR DESCRIPTION
…by lying to RTD about what theme we really are. :see_no_evil:

Resolves a long-standing issue with the controls for the versions panel being at the bottom left of the page (in the sidebar) but the panel content floating as a "badge" in the lower right corner of the page. See <https://github.com/nextstrain/docs.nextstrain.org/issues/76> for the diagnosis.

While fixing the underlying issue with RTD's code would be best, it isn't clear to me how to go about doing so, e.g. how to introspect theme inheritance.

