### PR TITLE
Require sphinx_rtd_theme >=1.0.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(
         ]
     },
     install_requires = [
-        'sphinx_rtd_theme'
+        'sphinx_rtd_theme >=1.0.0'
     ],
     classifiers = [
         'Framework :: Sphinx',


### PR DESCRIPTION
### Description of proposed changes

Starting with docutils 0.17, div.section has been replaced with section among other changes. This hasn't been a problem until recently when dependency resolution resolved to docutils 0.17, causing unwanted differences in CSS selector behavior using an older version of sphinx_rtd_theme [[1]].

sphinx_rtd_theme=1.0.0 is the first version to support docutils 0.17 [[2]].

[1]: https://github.com/nextstrain/ncov/issues/891
[2]: https://sphinx-rtd-theme.readthedocs.io/en/stable/changelog.html#release-1-0-0

### Related issue(s)

- nextstrain/docs.nextstrain.org#97
- nextstrain/ncov#891

### Testing

No testing