### PR TITLE
Publish to PyPI with GitHub Actions workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,44 @@
+name: Publish to PyPI
+on:
+  workflow_dispatch:
+    inputs:
+      pypi_instance:
+        # PyPI has a separate instance which can be used for testing purposes.
+        description: 'PyPI instance for publishing'
+        required: true
+        default: 'PyPI'
+        type: choice
+        options:
+        - 'TestPyPI'
+        - 'PyPI'
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+      - run: python3 -m pip install --upgrade build twine
+      # Generate the source and binary distributions with setup.py
+      # https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives
+      - run: python3 -m build
+      # Upload build as workflow artifact in case we need it
+      - uses: actions/upload-artifact@v3
+        with:
+          name: dist
+          path: dist/
+      - name: 'Publish to TestPyPI'
+        if: ${{ github.event.inputs.pypi_instance == 'TestPyPI' }}
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+      - name: 'Publish to PyPI'
+        if: ${{ github.event.inputs.pypi_instance == 'PyPI' }}
+        run: twine upload dist/*
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_API_TOKEN }}
+          TWINE_REPOSITORY_URL: https://pypi.org/legacy/

--- a/README.rst
+++ b/README.rst
@@ -57,8 +57,14 @@ Releasing
 3. Add a commit which describes the changes from the previous version to ``CHANGES.rst`` and updates the version number in ``lib/nextstrain/sphinx/theme/VERSION``.
 4. Tag this commit with the version number, e.g. ``git tag -a 2020.4 -m "version 2020.4"``.
 5. Push the commit and tag to GitHub, e.g. ``git push origin main 2020.4``.
-6. `Generate the source and binary distributions with setup.py <https://packaging.python.org/tutorials/packaging-projects/#generating-distribution-archives>`__.
-7. `Upload the two files from step 6 to PyPI with twine <https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives>`__.
+6. Publish to PyPI by invoking a GitHub Actions workflow:
+
+   1. Go to the workflow: `publish.yml <https://github.com/nextstrain/sphinx-theme/actions/workflows/publish.yml>`_.
+   2. Select **Run workflow**. In the new menu:
+
+      1. Select **Use workflow from** > **Tags** > new version number (e.g. 2020.4).
+      2. Set **PyPI instance for publishing** as *PyPI* (default) or *TestPyPI*. `More info <https://packaging.python.org/en/latest/guides/using-testpypi/>`_
+      3. Select **Run workflow**.
 
 .. _Sphinx theme: https://www.sphinx-doc.org/en/master/theming.html
 .. _Read The Docs: https://readthedocs.org


### PR DESCRIPTION
### Description of proposed changes

Adds a GitHub Actions workflow for publishing to PyPI as well as TestPyPI.

### Testing

- Tested in fork repo ([example run](https://github.com/victorlin/sphinx-theme/actions/runs/2006895796))

### Tasks to get this working

- [x] create [nextstrain-bot PyPI user](https://pypi.org/user/nextstrain-bot/)
- [x] generate PyPI token and add as GitHub org secret
- [ ] merge PR

### Post-merge tasks

- [ ] do release for nextstrain-sphinx-theme 2022.3 with new steps