### PR TITLE
Use normal font weight for second-level and deeper sidebar navigation links

### DIFF
--- a/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
+++ b/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
@@ -103,10 +103,6 @@ footer span.commit code,
   font-size: 1rem;
 }
 
-.wy-menu-vertical li ul li a {
-  font-weight: 300;
-}
-
 /* Remove sidebar TOC link colors, hover states, and borders */
 .wy-menu-vertical a {
   color: var(--text-color);


### PR DESCRIPTION
This dates from early in the theme's existence where I was trying to
match existing styles on the old nextstrain.org/docs.  In the current
context, it makes the links harder to read, and I don't think it works
well.

