### PR TITLE
Use heading color for mobile nav text and menu icon

### DIFF
--- a/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
+++ b/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
@@ -229,6 +229,14 @@ footer span.commit code,
 }
 
 
+/* Mobile nav (top bar heading + flyout menu icon)
+ */
+
+.wy-nav-top a, .wy-nav-top i {
+  color: var(--heading-color);
+}
+
+
 /* Footer styles. Largely chosen to mimic the previous rendering of the docs. See
 https://github.com/nextstrain/nextstrain.org/blob/b1e09e57e91ed0c9343e1cd3104877ec3c5344a4/static-site/src/components/Footer/index.jsx
 */


### PR DESCRIPTION
It _was_ white (from the base theme), which is far too close to the gray
background we set here in our theme.  Just overlooked by previous
customizations, I suspect.

### Testing
Built locally and looked good. Will review PR build too.

Before / After
<img width="50%" src="https://user-images.githubusercontent.com/79913/161848924-d7eef409-ade5-4263-81b6-840b87687e77.png"><img width="50%" src="https://user-images.githubusercontent.com/79913/161848938-22943a01-499c-47ca-8ea1-0b13cb0c4f66.png">