### PR TITLE
Include sphinx-copybutton with nextstrain-sphinx-theme

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -31,6 +31,7 @@ author = 'The Nextstrain Team'
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
+    'nextstrain.sphinx.theme',
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/doc/demo/demo.rst
+++ b/doc/demo/demo.rst
@@ -197,6 +197,22 @@ Emphasized lines with line numbers
        print 'This one is not...'
        print '...but this one is.'
 
+Code block with shell prompts
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Copy button should strip prompts and handle line continuations.
+
+.. code-block:: console
+
+    $ echo hello world | tr a-z A-Z
+    HELLO WORLD
+
+    $ curl https://nextstrain.org/flu/seasonal/h3n2/ha/2y                       \
+        --header 'Accept: application/vnd.nextstrain.dataset.main+json'         \
+        --compressed                                                            \
+            > flu_seasonal_h3n2_ha_2y.json
+    Downloading …
+
 Sidebar
 =======
 

--- a/lib/nextstrain/sphinx/theme/__init__.py
+++ b/lib/nextstrain/sphinx/theme/__init__.py
@@ -16,3 +16,6 @@ with version_path.open(encoding = "utf-8") as version_file:
 def setup(app):
     app.add_html_theme('nextstrain-sphinx-theme', str(package_dir))
     app.setup_extension('sphinx_copybutton')
+    # customize sphinx_copybutton https://sphinx-copybutton.readthedocs.io/en/latest/use.html
+    app.config['copybutton_prompt_text'] = '$ '
+    app.config['copybutton_line_continuation_character'] = '\\'

--- a/lib/nextstrain/sphinx/theme/__init__.py
+++ b/lib/nextstrain/sphinx/theme/__init__.py
@@ -15,3 +15,4 @@ with version_path.open(encoding = "utf-8") as version_file:
 
 def setup(app):
     app.add_html_theme('nextstrain-sphinx-theme', str(package_dir))
+    app.setup_extension('sphinx_copybutton')

--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
         ]
     },
     install_requires = [
-        'sphinx_rtd_theme >=1.0.0'
+        'sphinx_rtd_theme >=1.0.0',
+        'sphinx-copybutton'
     ],
     classifiers = [
         'Framework :: Sphinx',


### PR DESCRIPTION
### Description of proposed changes

This extension has been recently used in a few of Nextstrain's doc projects:

- https://github.com/nextstrain/docs.nextstrain.org/commit/cc2e2a85c66e36591d83b34b7195b1eff18b3ce7
- https://github.com/nextstrain/ncov/commit/650820252030f23267dd6ba8f5d207ff3cbf466a

Adding it to this package will make Nextstrain's doc projects more consistent going forwards.

Note: for this to work properly, this package must be used as an extension in addition to usage as a theme.
See eabffdf as an example.

### Related issue(s)

- Fixes #24 

### Testing

Tested locally, see PR preview.