### PR TITLE
Pin the logo, project name, version, and search box to the top of the sidebar

### DIFF
--- a/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
+++ b/lib/nextstrain/sphinx/theme/static/css/nextstrain.css
@@ -75,6 +75,14 @@ footer span.commit code,
   background: inherit;
 }
 
+/* Pin the Nextstrain logo, project name, version, and search box to the top of
+ * the sidebar when the sidebar scrolls.
+ */
+.wy-side-nav-search {
+  position: sticky;
+  top: 0;
+}
+
 /* Sub-project name, version (optional) and link back to the main docs */
 .wy-side-nav-search > div.subproject {
   margin-top: -1rem;


### PR DESCRIPTION
…when it scrolls.  This helps maintain the page's visual structure even
if the sidebar navigation is long and requires scrolling.

### Testing
- [x] Built docs.nextstrain.org locally with this theme change and clicked around.
- [x] Clicked around the demo docs, e.g. https://nextstrain--28.org.readthedocs.build/projects/sphinx-theme/en/28/demo/long.html#example-menu-9