### PR TITLE
Workaround compatibility issue with sphinx-markdown-tables and markdown packages

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,21 @@ setup(
     },
     install_requires = [
         'sphinx_rtd_theme >=1.0.0',
-        'sphinx-copybutton'
+        'sphinx-copybutton',
+
+        # Many of our projects use sphinx-markdown-tables, which is
+        # incompatible with markdown 3.4.0 due to API changes.¹  Fix this with a
+        # single dep pin here instead of pins in all of those projects.  The
+        # upshot is that previously-broken stable builds of projects (e.g. past
+        # releases) can be fixed retroactively since when re-built from the
+        # same source they'll find this new theme dep.  The same wouldn't be
+        # true if we patched each repo individually.
+        #
+        # XXX TODO: Remove this once the compat issue¹ is resolved.
+        #   -trs, 18 July 2022
+        #
+        # ¹ https://github.com/ryanfox/sphinx-markdown-tables/issues/36
+        'markdown <3.4.0',
     ],
     classifiers = [
         'Framework :: Sphinx',


### PR DESCRIPTION
See commentary in this commit, the upstream issue¹, our initial tracking
issue² (in another repo), and our Slack thread.³

¹ https://github.com/ryanfox/sphinx-markdown-tables/issues/36
² https://github.com/nextstrain/ncov/issues/982
³ https://bedfordlab.slack.com/archives/C01LCTT7JNN/p1658148441308079

### Testing
- [x] CI passes
- [x] Test that our other projects can successfully build with this PR