### PR TITLE
Revert "Workaround compatibility issue with sphinx-markdown-tables and markdown packages"

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -34,21 +34,7 @@ setup(
     },
     install_requires = [
         'sphinx_rtd_theme >=1.0.0',
-        'sphinx-copybutton',
-
-        # Many of our projects use sphinx-markdown-tables, which is
-        # incompatible with markdown 3.4.0 due to API changes.¹  Fix this with a
-        # single dep pin here instead of pins in all of those projects.  The
-        # upshot is that previously-broken stable builds of projects (e.g. past
-        # releases) can be fixed retroactively since when re-built from the
-        # same source they'll find this new theme dep.  The same wouldn't be
-        # true if we patched each repo individually.
-        #
-        # XXX TODO: Remove this once the compat issue¹ is resolved.
-        #   -trs, 18 July 2022
-        #
-        # ¹ https://github.com/ryanfox/sphinx-markdown-tables/issues/36
-        'markdown <3.4.0',
+        'sphinx-copybutton'
     ],
     classifiers = [
         'Framework :: Sphinx',


### PR DESCRIPTION
This reverts commit 88db52c9959dc8b35f676f51e3abd1115a8dc975.

sphinx-markdown-tables 0.0.16 was released with a patch.  Unfortunately
its dependencies weren't updated too, so this workaround now actively
breaks our docs builds because the newer sphinx-markdown-tables isn't
compatible with the older markdown version declared here.  See also
<https://github.com/ryanfox/sphinx-markdown-tables/issues/38>.

### Related issue(s)
Related to #29.

### Testing
- [ ] CI passes