### PR TITLE
Use the sphinx-better-subsection extension to use explicit targets for section permalinks

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -2,6 +2,19 @@
 Changelog
 =========
 
+Unreleased
+==========
+
+The ``sphinx-better-subsection`` extension is installed and automatically set
+up to prefer explicit targets for a section heading over auto-generated targets
+(e.g. from the title) when producing HTML permalinks.  This change is backwards
+compatible as both targets still work in both rST and HTML pages.  An example
+can be seen below for the `previous release heading <v2023.1_>`__.
+(`#38 <https://github.com/nextstrain/sphinx-theme/pull/38>`_)
+
+
+.. _v2023.1:
+
 2023.1 (16 February 2023)
 =========================
 

--- a/doc/demo/demo.rst
+++ b/doc/demo/demo.rst
@@ -308,6 +308,9 @@ This is a glossary with definition terms for thing like :term:`Writing`:
   Writing
      The process of putting thoughts into a medium for other people to :term:`read <Reading>`.
 
+
+.. _preferred:
+
 Targets
 -------
 
@@ -318,7 +321,8 @@ A reference can be found under `Inline Markup`_, above. `Inline
 hyperlink targets`_ are also possible.
 
 Section headers are implicit targets, referred to by name. See
-Targets_, which is a subsection of `Paragraph Level Markup`_.
+Targets_, which is a subsection of `Paragraph Level Markup`_. Explicit targets
+before a section heading are preferred_ when generating HTML permalinks.
 
 Explicit external targets are interpolated into references such as "Python_".
 

--- a/lib/nextstrain/sphinx/theme/__init__.py
+++ b/lib/nextstrain/sphinx/theme/__init__.py
@@ -15,6 +15,7 @@ with version_path.open(encoding = "utf-8") as version_file:
 
 def setup(app):
     app.add_html_theme('nextstrain-sphinx-theme', str(package_dir))
+    app.setup_extension('sphinx_better_subsection')
     app.setup_extension('sphinx_copybutton')
     # customize sphinx_copybutton https://sphinx-copybutton.readthedocs.io/en/latest/use.html
     app.config['copybutton_prompt_text'] = '$ '

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,8 @@ setup(
     },
     install_requires = [
         'sphinx_rtd_theme >=1.0.0',
-        'sphinx-copybutton'
+        'sphinx-better-subsection',
+        'sphinx-copybutton',
     ],
     classifiers = [
         'Framework :: Sphinx',


### PR DESCRIPTION
As that Python package requires ≥3.7, this theme will now too.  That's acceptable in the development contexts in which we generate docs, which should be using newer Pythons anyway.

c.f. <https://github.com/nextstrain/docs.nextstrain.org/commit/57fe1888#all_commit_comments>

### Testing

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [x] Demos work
- [x] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
