### PR TITLE
Changes for sphinx-rtd-theme 3.0.0

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -48,3 +48,7 @@ exclude_patterns = []
 # a list of builtin themes.
 #
 html_theme = 'nextstrain-sphinx-theme'
+
+html_theme_options = {
+    'flyout_display': 'attached',
+}


### PR DESCRIPTION
## Description of proposed changes

sphinx-rtd-theme 3.0.0 changed the default behavior to hide this flyout in favor of the Read the Docs flyout which was enabled by default [along with the 3.0.0 release](https://about.readthedocs.com/blog/2024/07/addons-by-default/). I'll plan to disable the RTD flyout on the RTD dashboard when this commit makes its way into RTD-hosted builds.

## Related issue(s)

https://github.com/nextstrain/docs.nextstrain.org/issues/216

## Checklist

<!--
Make sure checks are successful at the bottom of the PR.

If applicable, add:
- any changes to existing tests
- any additional manual testing to confirm changes

Please add a note if you need help with adding tests.
-->

- [ ] Checks pass

<!-- 🙌 Thank you for contributing to Nextstrain! ✨ -->
