### PR TITLE
readthedocs.yml: explicit Sphinx configuration

### DIFF
--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -6,6 +6,9 @@ build:
   tools:
     python: '3.11'
 
+sphinx:
+  configuration: doc/conf.py
+
 python:
   install:
     - method: pip


### PR DESCRIPTION
## Description of proposed changes

Prompted by deprecation of RTD's auto-detection of Sphinx configs 
<https://about.readthedocs.com/blog/2024/12/deprecate-config-files-without-sphinx-or-mkdocs-config/>

## Related issue(s)

Related to https://github.com/nextstrain/public/issues/15

## Checklist

- [x] Checks pass
